### PR TITLE
Updated merge-stream to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "hyphenation.en-us": "0.2.1",
     "hypher": "0.2.3",
     "json-loader": "0.5.3",
-    "merge-stream": "0.1.8",
+    "merge-stream": "1.0.0",
     "raw-loader": "0.5.1",
     "rsyncwrapper": "0.4.3",
     "val-loader": "0.5.0",


### PR DESCRIPTION
:rocket:

merge-stream just published version 1.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 8 commits (ahead by 8, behind by 0).
- [e973cf4](https://github.com/grncdr/merge-stream/commit/e973cf43ef0edda5d4e3b08b07040d4039822734): 1.0.0
- [8cfe117](https://github.com/grncdr/merge-stream/commit/8cfe1174317d5cf498f93b110e0c48209c095cf0): Tweak docs and add `merged.isEmpty` to it
- [c0d63b2](https://github.com/grncdr/merge-stream/commit/c0d63b28c0f102667345ab305228a0da32c99bcd): Merge pull request #16 from stevemao/patch-1
- [1b0dc33](https://github.com/grncdr/merge-stream/commit/1b0dc332a36776df9f659f4c448266bf5b0a7e34): Test on 'iojs' and use container based
- [cbcafd2](https://github.com/grncdr/merge-stream/commit/cbcafd2135117661f6855a15f8baf65604ab56b5): Merge pull request #17 from stevemao/stream2
- [b2346d8](https://github.com/grncdr/merge-stream/commit/b2346d8fb84ff97b95742861170ef7a47557d2eb): This is using Streams3
- [4d80351](https://github.com/grncdr/merge-stream/commit/4d803518889b3c1c0b9006beea87c36b4da3e213): Merge pull request #19 from shinnn/readable-stream
- [de24e67](https://github.com/grncdr/merge-stream/commit/de24e673a07f4822995aecfabda1f8663641a377): Use readable-stream v2, instead of through2 v0.6

See the [full diff](https://github.com/grncdr/merge-stream/compare/b6892439437a82700d278902f357be95258c2a52...e973cf43ef0edda5d4e3b08b07040d4039822734).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
