### PR TITLE
Updated gulp-image-resize to version 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-compile-handlebars": "0.5.0",
     "gulp-concat": "2.6.0",
     "gulp-eslint": "1.0.0",
-    "gulp-image-resize": "0.6.0",
+    "gulp-image-resize": "0.7.0",
     "gulp-less": "3.0.3",
     "gulp-livereload": "3.8.1",
     "gulp-markdown-to-json": "0.2.1",


### PR DESCRIPTION
:rocket:

gulp-image-resize just published version 0.7.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 7 commits (ahead by 7, behind by 0).
- [2195112](https://github.com/scalableminds/gulp-image-resize/commit/21951129add1c2fae13c41aefaa59ac6ca50e6a1): Bumped to 0.7.0
- [bda796d](https://github.com/scalableminds/gulp-image-resize/commit/bda796dc6032717a0278d9262ff79298e92edd69): Merge pull request #3 from webcaetano/master
- [a92f1ea](https://github.com/scalableminds/gulp-image-resize/commit/a92f1ead9ef09d4355986f8e1ed7f99e746c09c0): Merge pull request #2 from webcaetano/patch-1
- [bf93bef](https://github.com/scalableminds/gulp-image-resize/commit/bf93bef07571ed0e5631c7e6ad1dc8a8d3b79476): Merge pull request #4 from webcaetano/patch-2
- [4c0adaf](https://github.com/scalableminds/gulp-image-resize/commit/4c0adaff395c9ecf7788ffb73e7b159c3a81aab8): Update index.js
- [fd82b50](https://github.com/scalableminds/gulp-image-resize/commit/fd82b50d917d4beaa439fb59b989731e5dbae892): enable sharpen setup
- [5badea6](https://github.com/scalableminds/gulp-image-resize/commit/5badea67254e193ad0cc8073ec9f97d0207bafe0): Update README.md

See the [full diff](https://github.com/scalableminds/gulp-image-resize/compare/27a7c59450b8a588ff309abf2b398532128b3d51...21951129add1c2fae13c41aefaa59ac6ca50e6a1).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
